### PR TITLE
add missed body-parser dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -10,6 +10,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "body-parser": "^1.16.0",
     "express": "^4.14.0",
     "mongoose": "^4.6.7"
   }


### PR DESCRIPTION
Unable to start "index.js" due to missed body-parser dependency.